### PR TITLE
make reply ephemeral if not in bot-commands

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -47,10 +47,10 @@ client.on('messageCreate', (message) => {
 })
 
 client.on('interactionCreate', async interaction => {
+    // Make it ephemeral (only the user can see it) if it's not in bot commands channel
+    let isEphemeral = false;
     if (interaction.channelId !== process.env.CHANNEL_ID_BOT_COMMANDS) {
-        let channel = await client.channels.fetch(process.env.CHANNEL_ID_BOT_COMMANDS);
-        channel.send(`<@${interaction.user.id}> please only use bot commands in this channel`);
-        return;
+        isEphemeral = true;
     }
     if (!interaction.isCommand()) return;
     const command = client.commands.get(interaction.commandName);
@@ -58,7 +58,7 @@ client.on('interactionCreate', async interaction => {
     if (!command) return;
 
     try {
-        await command.execute(interaction);
+        await command.execute(interaction, isEphemeral);
     } catch (error) {
         console.error(error);
         await interaction.reply({ content: 'There was an error while executing this command!', ephemeral: true });

--- a/commands/profitCommands.js
+++ b/commands/profitCommands.js
@@ -19,7 +19,7 @@ module.exports = {
             await interaction.reply({content: "The name you provided was not found please check your spelling",
                 ephemeral: isEphemeral});
         } else {
-            await interaction.reply("fetching data...")
+            await interaction.reply({content: "fetching data...", ephemeral: isEphemeral})
             let response = await fetch(`https://sky.coflnet.com/api/flip/stats/player/${playerResponse[0].uuid}`);
             let data = await response.json();
             await interaction.editReply((name) + ' has made ' + formatToPriceToShorten(data.totalProfit, 0) + " In the last 7 days")

--- a/commands/profitCommands.js
+++ b/commands/profitCommands.js
@@ -10,12 +10,14 @@ module.exports = {
             .setDescription('the username of the player')
             .setRequired(true)
         ),
-    async execute(interaction) {
+    async execute(interaction, isEphemeral) {
         let name = interaction.options.getString('name');
         let res = await fetch(`https://sky.coflnet.com/api/search/player/${name}`);
         let playerResponse = await res.json();
         if (playerResponse.Slug === "player_not_found") {
-            await interaction.reply("The name you provided was not found please check your spelling");
+            // Sends using InteractionReplyOptions, making it ephemeral (only user can see) if isEphemeral is true
+            await interaction.reply({content: "The name you provided was not found please check your spelling",
+                ephemeral: isEphemeral});
         } else {
             await interaction.reply("fetching data...")
             let response = await fetch(`https://sky.coflnet.com/api/flip/stats/player/${playerResponse[0].uuid}`);


### PR DESCRIPTION
If the command was not run in the bot-commands channel, make the reply ephemeral (only the user can see it).

This means that the command still works and doesn't fail in that channel, but it doesn't spam either